### PR TITLE
chore: introduce production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,70 @@
+name: Production Deployment
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy-production:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        id: pnpm-install
+        with:
+          run_install: false
+
+      - name: Get pnpm version
+        id: pnpm-version
+        run: |
+          PNPM_VERSION=$(node -e "console.log(require('./package.json').packageManager.split('@')[1])")
+          echo "PNPM_VERSION=$PNPM_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install pnpm
+        run: npm i -g pnpm@${{ steps.pnpm-version.outputs.PNPM_VERSION }}
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install || pnpm install --no-frozen-lockfile
+        # First try with frozen-lockfile (default in CI), if that fails, update the lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install Wrangler
+        run: pnpm add -g wrangler
+
+      - name: Deploy to Cloudflare Pages (Production)
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Deploy to Cloudflare Pages production environment
+          # Not using --branch parameter ensures this deploys to the production URL
+          WRANGLER_OUTPUT=$(npx wrangler pages deploy dist --project-name=hardcore-ninja --commit-hash=${{ github.sha }} --commit-dirty=true)
+          echo "Wrangler output: $WRANGLER_OUTPUT"
+
+          # Log the production deployment
+          echo "Production deployment completed successfully"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating production deployments. The workflow is triggered by pushes to the `main` branch and handles installing dependencies, building the project, and deploying to Cloudflare Pages.

Production deployment automation:

* Added `.github/workflows/production.yml` to define a workflow that installs Node.js and pnpm, sets up caching for dependencies, builds the project, and deploys to Cloudflare Pages using Wrangler upon pushes to the `main` branch.